### PR TITLE
Added necessary build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Language support and accuracy may expand in the future with better optimization 
 
 You can develop this app by opening it in Android Studio. Otherwise, you can use Gradle to build the app like so:
 ```bash
+#After cloning cd into voice-input, then Download client-libraries 
+git clone https://gitlab.futo.org/alex/futopayclientlibraries dep/futopay/
+#Build the app
 ./gradlew assembleStandaloneRelease
 ```
 


### PR DESCRIPTION
The build instructions missed the necessary step to add the libraries for futopay, see https://github.com/futo-org/voice-input/issues/110

Now the build instructions are updated with these instructions.