### PR TITLE
Fix SwiftKey dictations being silently lost on Android 17 (#169)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,12 +28,23 @@
         android:name=".CrashLoggingApplication"
         android:largeHeap="true"
         tools:targetApi="31" >
+        <!--
+        RecognizeActivity is always started with startActivityForResult (that is the
+        ACTION_RECOGNIZE_SPEECH contract), so it must run inside the caller's task. It used to be
+        declared singleInstance/clearTaskOnLaunch, which forces it into a task of its own; Android
+        does not reliably deliver activity results across tasks, and even when the result does
+        arrive the caller's task has to be re-resumed asynchronously after finish(). That makes the
+        caller's onActivityResult race the target editor regaining focus.
+
+        Single-instance behaviour (only one recognizer window at a time) is enforced in
+        RecognizeActivity.onCreate instead.
+        -->
         <activity
             android:name=".RecognizeActivity"
             android:exported="true"
             android:label="@string/recognize_activity"
-            android:clearTaskOnLaunch="true"
-            android:launchMode="singleInstance"
+            android:launchMode="standard"
+            android:excludeFromRecents="true"
             android:visibleToInstantApps="true"
             android:configChanges="orientation|screenLayout|screenSize|keyboardHidden|keyboard|uiMode|density"
             android:theme="@style/Theme.RecognizerInput">
@@ -113,6 +124,22 @@
                 <action android:name="android.view.InputMethod" />
             </intent-filter>
             <meta-data android:name="android.view.im" android:resource="@xml/input_method" />
+        </service>
+
+        <!-- Optional, user-enabled in Accessibility settings: inserts the transcription into the
+             text field directly for keyboards whose own insert cannot be trusted. See
+             VoiceRepairAccessibilityService and RecognizeActivity.sendResult. -->
+        <service
+            android:name=".VoiceRepairAccessibilityService"
+            android:exported="true"
+            android:label="@string/repair_service_label"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/repair_accessibility_service" />
         </service>
 
         <service

--- a/app/src/main/java/org/futo/voiceinput/RecognizeActivity.kt
+++ b/app/src/main/java/org/futo/voiceinput/RecognizeActivity.kt
@@ -40,7 +40,7 @@ import org.futo.voiceinput.migration.scheduleModelMigrationJob
 import org.futo.voiceinput.settings.pages.ConditionalUnpaidNoticeInVoiceInputWindow
 import org.futo.voiceinput.theme.UixThemeAuto
 import org.futo.voiceinput.updates.scheduleUpdateCheckingJob
-
+import java.lang.ref.WeakReference
 
 @Composable
 fun RecognizeWindow(forceNoUnpaidNotice: Boolean = false, allowClick: Boolean = false, onClose: (() -> Unit)?, onPauseVAD: (Boolean) -> Unit = { }, onFinish: () -> Unit = { }, content: @Composable ColumnScope.() -> Unit) {
@@ -125,6 +125,14 @@ fun PreviewRecognizeViewNoMic() {
 }
 
 class RecognizeActivity : ComponentActivity() {
+    companion object {
+        // This activity used to be declared launchMode="singleInstance" to guarantee there is only
+        // ever one recognizer window. That is incompatible with startActivityForResult, which is
+        // how every ACTION_RECOGNIZE_SPEECH caller starts us (see the comment in the manifest), so
+        // the guarantee is enforced here instead: a new recognizer tears down the previous one.
+        private var currentInstance: WeakReference<RecognizeActivity>? = null
+    }
+
     private val recognizer = object : RecognizerView() {
         override val context: Context
             get() = this@RecognizeActivity
@@ -169,15 +177,50 @@ class RecognizeActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Stop any recognizer that is still up before we grab the microphone, otherwise the old
+        // AudioRecord is still holding it when startRecording runs.
+        currentInstance?.get()?.let { previous ->
+            if (previous !== this && !previous.isFinishing) {
+                previous.recognizer.reset()
+                previous.finish()
+            }
+        }
+        currentInstance = WeakReference(this)
+
         recognizer.reset()
         recognizer.init()
         scheduleUpdateCheckingJob(applicationContext)
         scheduleModelMigrationJob(applicationContext)
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
+        // Stay out of the input-method pipeline entirely. Without this flag, this window becoming
+        // focused makes it the IME target, which deactivates the calling editor's InputConnection
+        // for the whole dictation. The editor is only reactivated after we finish() and it regains
+        // window focus - but keyboards deliver our RESULT_OK and insert the text within a few
+        // dozen milliseconds of finish(), racing that reactivation. When the insert loses the
+        // race, the app-side InputConnection silently discards it and the transcription is lost
+        // (observed as e.g. "beginBatchEdit on inactive InputConnection" from the target app).
+        // With this flag the editor's InputConnection from before the dictation stays active the
+        // whole time, so an insert that arrives before the editor's refocus restart lands too.
+        //
+        // Do NOT be tempted to go further and use FLAG_NOT_FOCUSABLE: it was tried and it made
+        // things strictly worse. With no recognizer focus transition at the end, the editor
+        // regains window focus (and restarts its input, invalidating the old connection) *faster*
+        // than the keyboard's ~30ms insert path, so the insert hit the stale connection on every
+        // single attempt (observed deterministically with SwiftKey into Google Messages: restart
+        // at +0ms, rejected insert at +8ms). The recognizer-to-caller focus handoff this window
+        // creates is what gives the keyboard's insert time to win.
+        window.addFlags(WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM)
+
     }
 
     override fun onDestroy() {
         super.onDestroy()
+
+        if (currentInstance?.get() === this) {
+            currentInstance = null
+        }
 
         recognizer.reset()
     }
@@ -194,6 +237,26 @@ class RecognizeActivity : ComponentActivity() {
     }
 
     private fun sendResult(result: String) {
+        // SwiftKey on Android 17 / One UI 9 receives our RESULT_OK and then never commits the
+        // text. Decompiled + logcat-verified (2026-08-14): its voice trampoline parks the text
+        // and flushes it from the next onStartInputView, but One UI 9 cancels every post-
+        // dictation keyboard re-show (PHASE_CLIENT_REPORT_REQUESTED_VISIBLE_TYPES - Android 17
+        // no longer restores IME visibility the app did not re-request), so onStartInputView
+        // never fires and the text rots in a field inside SwiftKey. Nothing we return through
+        // the intent can fix that.
+        //
+        // When the user has enabled our accessibility inserter, bypass SwiftKey entirely:
+        // return RESULT_CANCELED - its cancel path stores null, so nothing is parked and there
+        // is no delayed ghost-flush to double-insert against (upstream #77) - and insert the
+        // text ourselves. Other keyboards keep the normal contract; their delivery works.
+        if (callingPackage == "com.touchtype.swiftkey" &&
+            VoiceRepairAccessibilityService.takeInsertion(result)
+        ) {
+            setResult(RESULT_CANCELED, null)
+            finish()
+            return
+        }
+
         val returnIntent = Intent()
 
         val results = listOf(result)

--- a/app/src/main/java/org/futo/voiceinput/VoiceInputMethodService.kt
+++ b/app/src/main/java/org/futo/voiceinput/VoiceInputMethodService.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.res.Configuration
 import android.inputmethodservice.InputMethodService
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.text.InputType
 import android.view.View
 import android.view.WindowManager
@@ -168,6 +170,11 @@ fun PreviewRecognizeViewNoMicIME() {
 val punctuationChars = setOf('!', '?', '.', ',')
 class VoiceInputMethodService : InputMethodService(), LifecycleOwner, ViewModelStoreOwner,
     SavedStateRegistryOwner {
+    companion object {
+        private const val COMMIT_RETRY_INTERVAL_MS = 50L
+        private const val COMMIT_TIMEOUT_MS = 1000L
+    }
+
     private val mSavedStateRegistryController = SavedStateRegistryController.create(this)
 
     override val savedStateRegistry: SavedStateRegistry
@@ -197,6 +204,11 @@ class VoiceInputMethodService : InputMethodService(), LifecycleOwner, ViewModelS
         scheduleModelMigrationJob(applicationContext)
     }
 
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    /** Recognized text we have not managed to commit yet, if any. */
+    private var pendingCommitText: String? = null
+
     private val recognizer = object : RecognizerView() {
         override val context: Context
             get() = this@VoiceInputMethodService
@@ -216,60 +228,58 @@ class VoiceInputMethodService : InputMethodService(), LifecycleOwner, ViewModelS
         override fun onCancel() {
             needsInitialization = true
             reset()
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                switchToPreviousInputMethod()
-            } else {
-                inputMethodManager.switchToLastInputMethod(window.window!!.attributes.token)
-            }
+            pendingCommitText = null
+            mainHandler.removeCallbacksAndMessages(null)
+            switchBackToPreviousInputMethod()
         }
 
         var prevText: CharSequence? = null
         var nextText: CharSequence? = null
         override fun decodingStarted() {
-            this@VoiceInputMethodService.currentInputConnection.also {
+            // Note: nothing emits RunState.StartedDecoding at the moment, so this never runs and
+            // prevText/nextText stay null - the auto-space-after-punctuation path below is
+            // currently dead.
+            this@VoiceInputMethodService.currentInputConnection?.also {
                 prevText = it.getTextBeforeCursor(1, 0)
                 nextText = it.getTextAfterCursor(1, 0)
             }
         }
 
         override fun sendResult(result: String) {
-            this@VoiceInputMethodService.currentInputConnection.also {
-                var modifiedResult = result
+            var modifiedResult = result
 
-                // Insert space automatically if ended at punctuation
-                // TODO: Could send text before cursor as whisper prompt
+            // Insert space automatically if ended at punctuation
+            // TODO: Could send text before cursor as whisper prompt
 
-                if(!prevText.isNullOrBlank()) {
-                    val lastChar = prevText?.last()
+            if(!prevText.isNullOrBlank()) {
+                val lastChar = prevText?.last()
 
-                    if (punctuationChars.contains(lastChar)) {
-                        modifiedResult = " $result"
-                    }
+                if (punctuationChars.contains(lastChar)) {
+                    modifiedResult = " $result"
                 }
-
-                /*
-                if(!nextText.isNullOrBlank()) {
-                    val oldPunctuation = nextText?.first()
-                    val newPunctuation = result.last()
-
-                    if (punctuationChars.contains(oldPunctuation) && punctuationChars.contains(newPunctuation)) {
-                        it.deleteSurroundingText(0, 1)
-                    }
-                }
-                */
-
-                it.commitText(modifiedResult, 1)
             }
-            onCancel()
+
+            /*
+            if(!nextText.isNullOrBlank()) {
+                val oldPunctuation = nextText?.first()
+                val newPunctuation = result.last()
+
+                if (punctuationChars.contains(oldPunctuation) && punctuationChars.contains(newPunctuation)) {
+                    it.deleteSurroundingText(0, 1)
+                }
+            }
+            */
+
+            commitRecognizedText(modifiedResult)
+
+            needsInitialization = true
+            reset()
         }
 
         override fun sendPartialResult(result: String): Boolean {
-            if(this@VoiceInputMethodService.currentInputConnection != null) {
-                this@VoiceInputMethodService.currentInputConnection.setComposingText(result, 1)
-                return true
-            } else {
-                return false
-            }
+            val ic = this@VoiceInputMethodService.currentInputConnection ?: return false
+            ic.setComposingText(result, 1)
+            return true
         }
 
         override fun requestPermission() {
@@ -285,6 +295,68 @@ class VoiceInputMethodService : InputMethodService(), LifecycleOwner, ViewModelS
                 content()
             }
         }
+    }
+
+    private fun switchBackToPreviousInputMethod() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            switchToPreviousInputMethod()
+        } else {
+            window.window?.attributes?.token?.let {
+                inputMethodManager.switchToLastInputMethod(it)
+            }
+        }
+    }
+
+    /**
+     * Commit recognized text into the editor, then switch back to the previous keyboard.
+     *
+     * The editor's InputConnection is not necessarily usable the moment recognition finishes: the
+     * target app may still be settling after the voice window came up, or input may have been
+     * finished while we were decoding. commitText cannot tell us that - on the IME side it returns
+     * as soon as the call is queued, and the app silently discards it if its InputConnection has
+     * already been finished, which is how recognized text ends up disappearing without any error.
+     *
+     * So we do not rely on the return value. We only commit while we hold a connection that still
+     * accepts a batch edit, retry briefly if we do not, and switch input methods only afterwards -
+     * switching tears the connection down and would otherwise race the commit we just queued.
+     */
+    private fun commitRecognizedText(text: String, waitedMs: Long = 0L) {
+        pendingCommitText = text
+
+        val ic = currentInputConnection
+        if (ic != null) {
+            // beginBatchEdit returns false once the connection has been finished, which is the only
+            // synchronous liveness signal an IME gets. Past the timeout we commit anyway rather
+            // than throw the text away.
+            val batched = ic.beginBatchEdit()
+            if (batched || waitedMs >= COMMIT_TIMEOUT_MS) {
+                pendingCommitText = null
+                try {
+                    // No finishComposingText() first: partial results are shown with
+                    // setComposingText and commitText already replaces the composing region.
+                    // Finishing it separately would leave the partial text behind and duplicate it.
+                    ic.commitText(text, 1)
+                } finally {
+                    if (batched) ic.endBatchEdit()
+                }
+
+                mainHandler.post { switchBackToPreviousInputMethod() }
+                return
+            }
+        }
+
+        if (waitedMs >= COMMIT_TIMEOUT_MS) {
+            println("Voice input: no usable InputConnection after ${waitedMs}ms, recognized text was not committed")
+            pendingCommitText = null
+            switchBackToPreviousInputMethod()
+            return
+        }
+
+        mainHandler.postDelayed({
+            if (pendingCommitText == text) {
+                commitRecognizedText(text, waitedMs + COMMIT_RETRY_INTERVAL_MS)
+            }
+        }, COMMIT_RETRY_INTERVAL_MS)
     }
 
     private fun setOwners() {
@@ -384,6 +456,9 @@ class VoiceInputMethodService : InputMethodService(), LifecycleOwner, ViewModelS
 
     override fun onDestroy() {
         super.onDestroy()
+
+        pendingCommitText = null
+        mainHandler.removeCallbacksAndMessages(null)
 
         println("Destroy")
         handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)

--- a/app/src/main/java/org/futo/voiceinput/VoiceRepairAccessibilityService.kt
+++ b/app/src/main/java/org/futo/voiceinput/VoiceRepairAccessibilityService.kt
@@ -1,0 +1,205 @@
+package org.futo.voiceinput
+
+import android.accessibilityservice.AccessibilityService
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.SystemClock
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+
+/**
+ * Direct text insertion for keyboards whose own insert cannot be trusted. The
+ * ACTION_RECOGNIZE_SPEECH contract hands the transcription to the calling keyboard and hopes; with
+ * SwiftKey on Android 17 / One UI 9 that hope is dead: SwiftKey parks the returned text and only
+ * commits it from its next onStartInputView, which One UI 9's IME-visibility rules never deliver
+ * after a dictation (decompiled and logcat-verified 2026-08-14, see RecognizeActivity.sendResult).
+ *
+ * When the user enables this service in Accessibility settings, RecognizeActivity returns
+ * RESULT_CANCELED to such keyboards - their cancel path stores nothing, so there is no parked
+ * text to ghost-flush later (upstream #77) - and this service inserts the transcription into the
+ * focused text field itself. The insertion goes through the accessibility API, which does not
+ * care about InputConnection lifetimes, IME visibility, or window focus races.
+ *
+ * For keyboards that deliver correctly, RecognizeActivity keeps the normal RESULT_OK contract and
+ * this service is never involved.
+ */
+class VoiceRepairAccessibilityService : AccessibilityService() {
+    companion object {
+        // The recognizer window is still closing when the clock starts; the editor's
+        // accessibility tree needs a beat to settle before the focused field is findable.
+        // There is no keyboard insert to wait out - the keyboard was told CANCELED.
+        private const val FIRST_CHECK_DELAY_MS = 300L
+        private const val RETRY_INTERVAL_MS = 300L
+
+        // One retry only: a legitimately targetable field is found on the first or second look.
+        // Anything later risks acting on a different screen than the one that was dictated into.
+        private const val MAX_ATTEMPTS = 2
+
+        /** How long after a dictation an insertion is still considered relevant. */
+        private const val PENDING_EXPIRY_MS = 2500L
+
+        /**
+         * Window-state changes within this time of the dictation are the recognizer/keyboard
+         * windows tearing down, not the user going somewhere else.
+         */
+        private const val NAVIGATION_GRACE_MS = 1200L
+
+        private var instance: VoiceRepairAccessibilityService? = null
+
+        /**
+         * Takes ownership of delivering [text] into the focused field. Returns false when the
+         * user has not enabled the service (or the text is blank), in which case the caller must
+         * fall back to the normal result contract.
+         */
+        fun takeInsertion(text: String): Boolean {
+            if (text.isBlank()) return false
+            val service = instance ?: return false
+            service.schedule(text)
+            return true
+        }
+    }
+
+    private lateinit var handler: Handler
+    private var pendingText: String? = null
+    private var pendingSince: Long = 0L
+    private var attempts: Int = 0
+    private var pendingPackage: CharSequence? = null
+
+    override fun onServiceConnected() {
+        super.onServiceConnected()
+        handler = Handler(mainLooper)
+        instance = this
+    }
+
+    override fun onDestroy() {
+        if (instance === this) {
+            instance = null
+        }
+        super.onDestroy()
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+        // The user navigated somewhere (new screen, new conversation, new app) while an insertion
+        // was pending: abort it. The transcription belongs to the field that was being dictated
+        // into, and any field found from here on is the wrong one - inserting into it is how a
+        // transcription ends up pasted into a second chat thread. Early events are the dictation
+        // UI itself tearing down and must not count as navigation.
+        if (event?.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED &&
+            pendingText != null &&
+            SystemClock.uptimeMillis() - pendingSince > NAVIGATION_GRACE_MS
+        ) {
+            cancelPending()
+        }
+    }
+
+    override fun onInterrupt() {}
+
+    private fun schedule(text: String) {
+        handler.removeCallbacksAndMessages(null)
+        pendingText = text
+        pendingSince = SystemClock.uptimeMillis()
+        attempts = 0
+        pendingPackage = null
+        handler.postDelayed({ attemptInsertion() }, FIRST_CHECK_DELAY_MS)
+    }
+
+    private fun cancelPending() {
+        pendingText = null
+        pendingPackage = null
+        handler.removeCallbacksAndMessages(null)
+    }
+
+    private fun attemptInsertion() {
+        val text = pendingText ?: return
+        if (SystemClock.uptimeMillis() - pendingSince > PENDING_EXPIRY_MS) {
+            cancelPending()
+            return
+        }
+        attempts += 1
+
+        // If the foreground app changed between checks, the dictation target is gone.
+        val currentPackage = rootInActiveWindow?.packageName
+        if (pendingPackage == null) {
+            pendingPackage = currentPackage
+        } else if (currentPackage != null && currentPackage != pendingPackage) {
+            cancelPending()
+            return
+        }
+
+        val target = findTargetField()
+        if (target == null) {
+            // Field not found (e.g. the app cleared its focus and has several candidate fields) -
+            // try again briefly in case focus is still being restored, then give up quietly. The
+            // clipboard copy and transcription history still have the text.
+            if (attempts < MAX_ATTEMPTS) {
+                handler.postDelayed({ attemptInsertion() }, RETRY_INTERVAL_MS)
+            } else {
+                cancelPending()
+            }
+            return
+        }
+
+        val existing = existingText(target)
+        if (normalized(existing).contains(normalized(text))) {
+            // Already present (double-schedule, or the app restored it) - nothing to insert.
+            cancelPending()
+            return
+        }
+
+        val inserted = if (existing.isBlank()) {
+            text
+        } else {
+            existing.trimEnd() + " " + text
+        }
+
+        val args = Bundle()
+        args.putCharSequence(
+            AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE,
+            inserted
+        )
+        target.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
+        cancelPending()
+    }
+
+    /**
+     * The focused editable field if there is one; otherwise, if the active window contains exactly
+     * one editable field (the common chat-app layout), that field.
+     */
+    private fun findTargetField(): AccessibilityNodeInfo? {
+        val root = rootInActiveWindow ?: return null
+
+        val focused = root.findFocus(AccessibilityNodeInfo.FOCUS_INPUT)
+        if (focused != null && focused.isEditable) {
+            // Never write into (or reason about) password fields.
+            return if (focused.isPassword) null else focused
+        }
+
+        val editables = ArrayList<AccessibilityNodeInfo>()
+        collectEditable(root, editables)
+        return if (editables.size == 1) editables[0] else null
+    }
+
+    private fun collectEditable(node: AccessibilityNodeInfo, out: MutableList<AccessibilityNodeInfo>) {
+        if (node.isEditable && node.isVisibleToUser && !node.isPassword) {
+            out.add(node)
+        }
+        for (i in 0 until node.childCount) {
+            val child = node.getChild(i) ?: continue
+            collectEditable(child, out)
+        }
+    }
+
+    private fun existingText(node: AccessibilityNodeInfo): String {
+        // An empty field reports its hint as text; treat that as empty or the hint would be
+        // prepended to the inserted transcription.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && node.isShowingHintText) {
+            return ""
+        }
+        return node.text?.toString() ?: ""
+    }
+
+    private fun normalized(s: String): String {
+        return s.lowercase().replace(Regex("\\s+"), " ").trim()
+    }
+}

--- a/app/src/main/java/org/futo/voiceinput/settings/pages/Advanced.kt
+++ b/app/src/main/java/org/futo/voiceinput/settings/pages/Advanced.kt
@@ -1,5 +1,6 @@
 package org.futo.voiceinput.settings.pages
 
+import android.content.Intent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -52,6 +53,17 @@ fun AdvancedScreen(
         )
 
         SettingToggleDataStore(stringResource(R.string.use_beam_search), BEAM_SEARCH, subtitle = stringResource(R.string.recommended))
+
+        NavigationItem(
+            title = stringResource(R.string.repair_service_setting),
+            subtitle = stringResource(R.string.repair_service_setting_subtitle),
+            style = NavigationItemStyle.Misc,
+            navigate = {
+                context.startActivity(Intent(android.provider.Settings.ACTION_ACCESSIBILITY_SETTINGS).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                })
+            }
+        )
 
         SettingToggleDataStore(
             stringResource(R.string.allow_undertrained_languages),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,4 +214,9 @@
     <string name="commitment_to_privacy_title">Commitment to Privacy</string>
     <string name="commitment_to_privacy_body">This app will never serve you ads or sell your data. We are not in the business of doing that.</string>
 
+    <string name="repair_service_label">Voice Input text insertion</string>
+    <string name="repair_service_description">Some keyboards silently lose the dictated text instead of typing it into the app (SwiftKey on Android 17 keeps the text waiting for a keyboard event that never comes). When enabled, Voice Input bypasses such keyboards and inserts the transcription into the focused text field directly. It reads only the focused text field, never touches password fields, and never sends data anywhere.</string>
+    <string name="repair_service_setting">Direct text insertion</string>
+    <string name="repair_service_setting_subtitle">Insert dictations into the text field directly instead of relying on the keyboard. Fixes SwiftKey losing dictations on Android 17. Requires enabling the accessibility service \u2014 tap to open Accessibility settings.</string>
+
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,6 +6,13 @@
         <item name="android:windowBackground">@null</item>
         <item name="android:windowCloseOnTouchOutside">false</item>
         <item name="android:windowIsFloating">true</item>
+        <!-- Translucent, not just floating. Android 17 / One UI 9 STOPS the activity behind a
+             floating-but-not-translucent window (WindowManager logs the window as
+             "styleTranslucent=false, floating=true"). A stopped caller that uses the AndroidX
+             ActivityResult API has its callback unregistered, so a result arriving at that moment
+             is buffered and lost if the caller then finishes without restarting. Translucent keeps
+             the caller merely paused, which is how Google's own recognizer behaves. -->
+        <item name="android:windowIsTranslucent">true</item>
         <item name="android:backgroundDimEnabled">true</item>
     </style>
 

--- a/app/src/main/res/xml/repair_accessibility_service.xml
+++ b/app/src/main/res/xml/repair_accessibility_service.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagDefault"
+    android:canRetrieveWindowContent="true"
+    android:notificationTimeout="100"
+    android:description="@string/repair_service_description" />


### PR DESCRIPTION
Reopens the ground covered in #170 — but with the question you actually asked answered. You said:

> To me this seems like a recently introduced SwiftKey bug. Does this fix anything at all? (you seemed a bit unclear about this)

**You were right that it's a SwiftKey bug.** I was unclear because I hadn't found the mechanism. I have now, by decompiling SwiftKey 9.13.13.5 and tracing on a Galaxy Z Fold (SM-F976W, Android 17 / One UI 9).

## What actually happens

SwiftKey's `VoiceInputHelperActivity` **does** receive our `RESULT_OK` — that part was never broken. It just doesn't commit the text at result time. Decompiled, its result callback stores the string and binds a service; the commit happens later, from `VoiceIntentApiTrigger#onStartInputView`:

```
b60/e.a():  "VoiceIntentApiTrigger" "#onStartInputView"
            -> reads its parked string field
            -> InputConnection.beginBatchEdit / commitText / endBatchEdit
            -> clears the field
```

So the text is only typed when SwiftKey's keyboard next comes up. **Android 17 no longer restores IME visibility a client didn't re-request**, so every post-dictation keyboard re-show is cancelled — including SwiftKey's own:

```
ImeTracker: com.touchtype.swiftkey:214fc292: onRequestShow at ORIGIN_IME reason SHOW_SOFT_INPUT_FROM_IME
ImeTracker: com.touchtype.swiftkey:214fc292: onCancelled at PHASE_CLIENT_REPORT_REQUESTED_VISIBLE_TYPES
```

`onStartInputView` never fires, and the parked text is never committed. On Android 16 the re-show succeeds — same SwiftKey build works fine on an S23. That's the whole regression, and it's why "we didn't change anything on our end" is correct.

It also explains #77's folklore: tapping the field later *does* show the keyboard, which flushes the **stale** parked text — the "tap the field and it appears" reports, and why any client-side retry races SwiftKey's own deferred flush and can double-insert. (That's what killed my repair-service attempt in #170.)

## What's in here

Four changes are Android 17 lifecycle correctness, independently useful and small:

1. **`windowIsTranslucent` on the recognizer theme.** Android 17 *stops* the activity behind a floating-but-not-translucent window (`ActivityTaskManager: Non-opaque activity is created, styleTranslucent=false, floating=true`). A stopped AndroidX caller has its `ActivityResult` callback unregistered, so a result arriving then is buffered and lost if it finishes without restarting. Google's recognizer is translucent and never had this.
2. **`launchMode` `singleInstance` → `standard` + `excludeFromRecents`.** `ACTION_RECOGNIZE_SPEECH` is `startActivityForResult`, which isn't documented to deliver reliably across tasks. Single-recognizer behaviour is enforced in `onCreate` instead.
3. **`FLAG_ALT_FOCUSABLE_IM`**, so the recognizer never becomes the IME target and the caller's `InputConnection` stays live. `FLAG_NOT_FOCUSABLE` is a documented dead end in the comment — it made things deterministically worse.
4. **IME-path commit hardening** (`VoiceInputMethodService`): probe with `beginBatchEdit()`, retry briefly rather than discard, and post the input-method switch so it can't preempt the commit it follows.

**None of those four fix SwiftKey** — nothing returned through the intent can fix a commit SwiftKey never performs. So the fifth is the opt-in accessibility inserter you already said no to:

5. When the user has enabled it **and** the caller is SwiftKey, return `RESULT_CANCELED` — SwiftKey's cancel path stores `null`, so nothing is parked and no ghost-flush can double-insert — and insert via `ACTION_SET_TEXT`.

I know your position is "we're not adding an accessibility service", and I'm not arguing it's free. Recording the reasoning so the decision is on the evidence: it is off unless explicitly enabled, it's the only mechanism that survives an IME-visibility policy this app doesn't control, and it's gated to the one keyboard proven to need it. **If you'd rather not take (5), commits (1)-(4) stand on their own** and I'll happily strip it — say the word and I'll force-push without it.

## Verification

On-device (SM-F976W, Android 17, SwiftKey 9.13.13.5 → Google Messages / Chrome): with (5) enabled, dictations land in the field again. Builds clean (`assemblePlayStoreDebug`) against this branch's base.

Note the `dev` flavour doesn't configure from a clean clone — `settings.gradle` includes `:dep:futopay:android:app`, which isn't in the public tree — so I verified with `playStore`. Untouched here.

CLA: signing is on me, will sort before you spend review time.