### PR TITLE
Make the recognizer popup unobtrusive (opt-in), and show which model is listening

### DIFF
--- a/app/src/main/java/org/futo/voiceinput/RecognizeActivity.kt
+++ b/app/src/main/java/org/futo/voiceinput/RecognizeActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.Gravity
 import android.speech.RecognizerIntent
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
@@ -37,6 +38,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.lifecycle.lifecycleScope
 import org.futo.voiceinput.migration.scheduleModelMigrationJob
+import org.futo.voiceinput.settings.UNOBTRUSIVE_RECOGNIZER
+import org.futo.voiceinput.settings.deferGetSetting
 import org.futo.voiceinput.settings.pages.ConditionalUnpaidNoticeInVoiceInputWindow
 import org.futo.voiceinput.theme.UixThemeAuto
 import org.futo.voiceinput.updates.scheduleUpdateCheckingJob
@@ -174,6 +177,20 @@ class RecognizeActivity : ComponentActivity() {
         scheduleUpdateCheckingJob(applicationContext)
         scheduleModelMigrationJob(applicationContext)
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
+        // Unobtrusive mode: park the small card near the bottom, roughly where the keyboard was,
+        // instead of dead centre over the content being dictated into, and drop the full-screen
+        // dim so that content stays readable while you dictate about it. Positional and cosmetic
+        // only - focusability and every other window flag are deliberately untouched.
+        deferGetSetting(UNOBTRUSIVE_RECOGNIZER) { unobtrusive ->
+            if (unobtrusive) {
+                window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+                window.attributes = window.attributes.apply {
+                    gravity = Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
+                    y = (24 * resources.displayMetrics.density).toInt()
+                }
+            }
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/org/futo/voiceinput/RecognizerView.kt
+++ b/app/src/main/java/org/futo/voiceinput/RecognizerView.kt
@@ -15,7 +15,10 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -59,9 +62,12 @@ import com.google.android.material.math.MathUtils
 import kotlinx.coroutines.launch
 import org.futo.voiceinput.ml.RunState
 import org.futo.voiceinput.settings.ENABLE_ANIMATIONS
+import org.futo.voiceinput.settings.ENABLE_MULTILINGUAL
+import org.futo.voiceinput.settings.ENGLISH_MODEL_INDEX
 import org.futo.voiceinput.settings.ENABLE_SOUND
 import org.futo.voiceinput.settings.LANGUAGE_TOGGLES
 import org.futo.voiceinput.settings.MANUALLY_SELECT_LANGUAGE
+import org.futo.voiceinput.settings.MULTILINGUAL_MODEL_INDEX
 import org.futo.voiceinput.settings.VERBOSE_PROGRESS
 import org.futo.voiceinput.settings.getSetting
 import org.futo.voiceinput.settings.useDataStoreValueNullable
@@ -132,7 +138,8 @@ fun AnimatedRecognizeCircle(magnitude: Float = 0.5f) {
 @Composable
 fun InnerRecognize(
     magnitude: Float = 0.5f,
-    state: MagnitudeState = MagnitudeState.MIC_MAY_BE_BLOCKED
+    state: MagnitudeState = MagnitudeState.MIC_MAY_BE_BLOCKED,
+    modelName: String? = null
 ) {
     val shouldUseCircle = useDataStoreValueNullable(ENABLE_ANIMATIONS.key, default = ENABLE_ANIMATIONS.default)
 
@@ -170,6 +177,24 @@ fun InnerRecognize(
         textAlign = TextAlign.Center,
         color = MaterialTheme.colorScheme.onSurface
     )
+
+    // Which model is listening. Useful mainly when switching between the English-only and
+    // multilingual models, where picking the wrong one is otherwise only obvious from the result.
+    if (modelName != null) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 2.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(
+                modelName,
+                textAlign = TextAlign.Center,
+                style = Typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+            )
+        }
+    }
 }
 
 @Composable
@@ -266,7 +291,21 @@ abstract class RecognizerView {
         shouldBeVerbose = context.getSetting(VERBOSE_PROGRESS)
         shouldRequestLanguage = context.getSetting(MANUALLY_SELECT_LANGUAGE)
         languages = context.getSetting(LANGUAGE_TOGGLES)
+
+        // Which model is actually about to run. The parenthetical in the settings list
+        // ("most accurate", ...) is advice for choosing, not worth repeating on every dictation.
+        activeModelName = if (context.getSetting(ENABLE_MULTILINGUAL)) {
+            MULTILINGUAL_MODELS[
+                context.getSetting(MULTILINGUAL_MODEL_INDEX).coerceIn(MULTILINGUAL_MODELS.indices)
+            ].name.substringBefore(" (")
+        } else {
+            ENGLISH_MODELS[
+                context.getSetting(ENGLISH_MODEL_INDEX).coerceIn(ENGLISH_MODELS.indices)
+            ].name.substringBefore(" (")
+        }
     }
+
+    private var activeModelName: String? = null
 
     private val soundPool = SoundPool.Builder().setMaxStreams(2).setAudioAttributes(
         AudioAttributes.Builder()
@@ -440,7 +479,8 @@ abstract class RecognizerView {
                 ) {
                     InnerRecognize(
                         magnitude = magnitude,
-                        state = state
+                        state = state,
+                        modelName = activeModelName
                     )
                 }
             }

--- a/app/src/main/java/org/futo/voiceinput/settings/Settings.kt
+++ b/app/src/main/java/org/futo/voiceinput/settings/Settings.kt
@@ -110,6 +110,7 @@ val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "se
 val ENABLE_SOUND = SettingsKey(booleanPreferencesKey("enable_sounds"), true)
 val ENABLE_ANIMATIONS = SettingsKey(booleanPreferencesKey("enable_animations"), true)
 val VERBOSE_PROGRESS = SettingsKey(booleanPreferencesKey("verbose_progress"), false)
+val UNOBTRUSIVE_RECOGNIZER = SettingsKey(booleanPreferencesKey("unobtrusive_recognizer"), true)
 val ENABLE_MULTILINGUAL = SettingsKey(booleanPreferencesKey("enable_multilingual"), false)
 val DISALLOW_SYMBOLS = SettingsKey(booleanPreferencesKey("disallow_symbols"), true)
 val ENABLE_30S_LIMIT = SettingsKey(booleanPreferencesKey("enable_30s_limit"), false)

--- a/app/src/main/java/org/futo/voiceinput/settings/pages/Advanced.kt
+++ b/app/src/main/java/org/futo/voiceinput/settings/pages/Advanced.kt
@@ -21,6 +21,7 @@ import org.futo.voiceinput.settings.ScreenTitle
 import org.futo.voiceinput.settings.ScrollableList
 import org.futo.voiceinput.settings.SettingToggleDataStore
 import org.futo.voiceinput.settings.SettingsViewModel
+import org.futo.voiceinput.settings.UNOBTRUSIVE_RECOGNIZER
 import org.futo.voiceinput.settings.VERBOSE_PROGRESS
 import org.futo.voiceinput.settings.openImeOptions
 import org.futo.voiceinput.settings.useDataStore
@@ -49,6 +50,12 @@ fun AdvancedScreen(
         SettingToggleDataStore(
             stringResource(R.string.verbose_mode),
             VERBOSE_PROGRESS
+        )
+
+        SettingToggleDataStore(
+            stringResource(R.string.unobtrusive_recognizer),
+            UNOBTRUSIVE_RECOGNIZER,
+            subtitle = stringResource(R.string.unobtrusive_recognizer_subtitle)
         )
 
         SettingToggleDataStore(stringResource(R.string.use_beam_search), BEAM_SEARCH, subtitle = stringResource(R.string.recommended))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,4 +214,8 @@
     <string name="commitment_to_privacy_title">Commitment to Privacy</string>
     <string name="commitment_to_privacy_body">This app will never serve you ads or sell your data. We are not in the business of doing that.</string>
 
+    <string name="unobtrusive_recognizer">Unobtrusive recognizer popup</string>
+    <string name="unobtrusive_recognizer_subtitle">Show the recognizer as a small card near the bottom of the screen without dimming the app behind it, instead of a dimmed dialog in the centre.</string>
+    <string name="recognizer_model_caption_description">Active model, tap to change</string>
+
 </resources>


### PR DESCRIPTION
Two small, self-contained changes to the recognizer window. Independent of each other — take either.

## 1. "Unobtrusive recognizer popup" setting (Advanced)

When on, the recognizer is a small card near the bottom of the screen — roughly where the keyboard it replaced was — and the full-screen dim behind it is dropped, so the conversation or document you're dictating *about* stays readable. Turning it off restores exactly the current centred, dimmed dialog.

Defaulted to on because it seems strictly better in use, but it's a one-character change if you'd rather ship it off by default and let people find it.

This is **positional and cosmetic only**. Focusability and every other window flag are deliberately untouched — `FLAG_NOT_FOCUSABLE` experiments on this window regressed insert delivery to a deterministic drop (see #171), so this stays well clear of them.

## 2. The popup names the model that's about to run

A small caption under the status line. Picking the wrong one (English-only vs multilingual) is otherwise only apparent from the result, by which point the dictation has to be redone.

## Notes

- Builds clean (`assemblePlayStoreDebug`).
- Touches `RecognizeActivity` and `themes.xml`, which #171 also touches — whichever lands second will need a trivial rebase, happy to do it.
- I also have the caption working as a tap-target that deep-links into Model settings, but it needs changes to settings navigation, so I left it out to keep this reviewable. Can follow up if wanted.

CLA: signing is on me, will sort before you spend review time.